### PR TITLE
feat: add register wrappers

### DIFF
--- a/specs/bridges/mean/readme.md
+++ b/specs/bridges/mean/readme.md
@@ -1,0 +1,61 @@
+# Spec for Mean Finance Bridge
+
+## What does the bridge do? Why did you build it?
+
+The bridge allows a user to enter a DCA (Dollar Cost Average) position, selling one asset and buying another over a period of time.
+
+## What protocol(s) does the bridge interact with?
+
+The bridge interacts only with Mean Finance.
+
+## What is the flow of the bridge?
+
+The bridge is asynchronous and has two flows: the deposit + the withdraw.
+
+### Deposit (L2)
+
+When users create a DCA position, they must specify:
+- The "from" token
+- The "to" token
+- Amount of "from" token
+- Swap interval (daily, weekly, etc)
+- Amount of swaps
+
+Also, the bridge supports the ability to generate yield while the DCA position is executed (both on the "from" and "to" tokens)
+
+### Withdraw/finalise (L1)
+
+A position needs to be finalised before it can be exited.
+For a position to be ready to be finalised, all its available funds must have been sold for the opposite asset.
+When finalised, the accumulated funds will be returned to the bridge and the user may claim them on L2.
+
+## Please list any edge cases that may restrict the usefulness of the bridge or that the bridge explicitly prevents.
+
+### Preparation
+* In order for swaps to work, tokens need to be pre-approved on the smart contract. This will give the rollup and the DCA Hub max allowance to work correctly.
+
+* Also, yield bearing wrappers need to be properly registered on the bridge.
+
+Both these configurations are permissionless and anyone can execute them.
+
+### Edge cases
+There are two scenarios where the swaps might not be executed:
+
+1. If all swaps are paused (this would happen in the case of a vulnerability)
+1. If one of the tokens in the positions is no longer allowed
+
+In any of these scenarios, users will be able to withdraw both the swapped and unswapped funds back to L2.
+
+## How can the accounting of the bridge be impacted by interactions performed by other parties than the bridge?
+
+The accounting could only be impacted by a vulnerability on Mean Finance's side. If this doesn't happen, then everything should work as expected.
+
+## Is this contract upgradable? If so, what are the restrictions on upgradability?
+
+The contract is immutable, but there is an owner. The owner can only set and modify subsidies for certain pairs.
+
+## Does this bridge maintain state? If so, what is stored and why?
+
+The bridge maintains the following state:
+- The association between user interaction and DCA position
+- A registry for supported yield-bearing wrappers

--- a/src/bridges/mean/MeanBridge.sol
+++ b/src/bridges/mean/MeanBridge.sol
@@ -124,8 +124,8 @@ contract MeanBridge is BridgeBase, Ownable2Step {
         (address _from, address _to) = _getTokensFromAuxData(_inputAssetA, _outputAssetA, _auxData);
 
         // Terminate position and clean things up
-        delete positionByNonce[_interactionNonce];
         uint256 _positionId = positionByNonce[_interactionNonce];
+        delete positionByNonce[_interactionNonce];
         (uint256 _unswapped, uint256 _swapped) = DCA_HUB.terminate(_positionId, THIS_ADDRESS, THIS_ADDRESS);
 
         if (_unswapped > 0) {

--- a/src/bridges/mean/MeanBridge.sol
+++ b/src/bridges/mean/MeanBridge.sol
@@ -271,7 +271,9 @@ contract MeanBridge is BridgeBase, Ownable2Step {
     function _wrapIfNeeded(AztecTypes.AztecAsset memory _inputAsset, address _hubToken, uint256 _amountToWrap) internal returns (uint256 _wrappedAmount) {
         if (_inputAsset.assetType == AztecTypes.AztecAssetType.ETH) {
             WETH.deposit{value: _amountToWrap}();            
-        } else if (_inputAsset.erc20Address != _hubToken) {
+            _inputAsset.erc20Address = address(WETH);
+        } 
+        if (_inputAsset.erc20Address != _hubToken) {
             ITransformer.UnderlyingAmount[] memory _underlying = new ITransformer.UnderlyingAmount[](1);
             _underlying[0] = ITransformer.UnderlyingAmount({underlying: _inputAsset.erc20Address, amount: _amountToWrap});
             return TRANSFORMER_REGISTRY.transformToDependent(
@@ -293,9 +295,10 @@ contract MeanBridge is BridgeBase, Ownable2Step {
         bool _isOutputAssetA
     ) internal returns (uint256 _unwrappedAmount) {
         if (_outputAsset.assetType == AztecTypes.AztecAssetType.ETH) {
-            WETH.withdraw(_amountToUnwrap);
-            IRollupProcessor(ROLLUP_PROCESSOR).receiveEthFromBridge{value: _amountToUnwrap}(_interactionNonce);
-        } else if (_outputAsset.erc20Address != _hubToken) {
+            _outputAsset.erc20Address = address(WETH);
+        }
+
+        if (_outputAsset.erc20Address != _hubToken) {
             ITransformer.UnderlyingAmount[] memory _underlying = TRANSFORMER_REGISTRY.transformToUnderlying(
                 _hubToken, 
                 _amountToUnwrap, 
@@ -310,8 +313,14 @@ contract MeanBridge is BridgeBase, Ownable2Step {
                     revert ErrorLib.InvalidOutputB();
                 }
             }
-            return _underlying[0].amount;
+            _amountToUnwrap = _underlying[0].amount;
         }
+
+        if (_outputAsset.assetType == AztecTypes.AztecAssetType.ETH) {
+            WETH.withdraw(_amountToUnwrap);
+            IRollupProcessor(ROLLUP_PROCESSOR).receiveEthFromBridge{value: _amountToUnwrap}(_interactionNonce);
+        }
+
         return _amountToUnwrap;
     }
 
@@ -342,14 +351,10 @@ contract MeanBridge is BridgeBase, Ownable2Step {
     }
 
     function _mapAssetToAddress(AztecTypes.AztecAsset memory _asset, uint64 _auxData, uint256 _shift) internal view returns(address _address) {
-        if (_asset.assetType == AztecTypes.AztecAssetType.ETH) {
-            return address(WETH);
-        } else {
-            uint256 _wrapperId = uint16(_auxData >> _shift);
-            return _wrapperId == 0 
-                ? _asset.erc20Address
-                : tokenWrapperRegistry.at(_wrapperId - 1);
-        }
+        uint256 _wrapperId = uint16(_auxData >> _shift);
+        return _wrapperId == 0 
+            ? (_asset.assetType == AztecTypes.AztecAssetType.ETH ? address(WETH) : _asset.erc20Address)
+            : tokenWrapperRegistry.at(_wrapperId - 1);
     }    
 
 }

--- a/src/bridges/mean/MeanBridge.sol
+++ b/src/bridges/mean/MeanBridge.sol
@@ -30,6 +30,7 @@ contract MeanBridge is BridgeBase, Ownable2Step {
     IWETH public constant WETH = IWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
     IDCAHub public immutable DCA_HUB;
     ITransformerRegistry public immutable TRANSFORMER_REGISTRY;
+    mapping(uint256 => uint256) public positionByNonce;
     address private immutable THIS_ADDRESS;
 
     // Note: Mean supports yield-while-DCAing and we want to support it here too. The thing
@@ -56,6 +57,43 @@ contract MeanBridge is BridgeBase, Ownable2Step {
 
     // Note: we need to be able to receive ETH to deposit as WETH
     receive() external payable {}
+
+    /**
+     * @notice A function which will allow the user to create DCA positions on Mean Finance
+     * @param _inputAssetA - ETH or ERC20 token to deposit and start swapping
+     * @param _outputAssetA - ETH or ERC20 token to swap funds into
+     * @param _inputValue - Amount to deposit
+     * @param _interactionNonce - Unique identifier for this DeFi interaction
+     * @param _auxData - The amount of swaps, swap interval and wrappers encoded together
+     * @param _rollupBeneficiary - Address which receives subsidy if the call is eligible for it
+     */
+    function convert(
+        AztecTypes.AztecAsset memory _inputAssetA,
+        AztecTypes.AztecAsset memory,
+        AztecTypes.AztecAsset memory _outputAssetA,
+        AztecTypes.AztecAsset memory _outputAssetB,
+        uint256 _inputValue,
+        uint256 _interactionNonce,
+        uint64 _auxData,
+        address _rollupBeneficiary
+    ) external payable override(BridgeBase) onlyRollup returns (uint256, uint256, bool) {
+        if (_inputAssetA.assetType != _outputAssetB.assetType || _inputAssetA.erc20Address != _outputAssetB.erc20Address) {
+            // We are making sure that input asset A = output asset B. We do this so that, if we need to, we can close the 
+            // position while it's still being swapped
+            revert ErrorLib.InvalidOutputB();
+        }
+
+        // Wrap the input asset (if needed) and deposit into the DCA Hub
+        (uint256 _positionId, uint256 _criteria) = _wrapAndDeposit(_inputAssetA, _outputAssetA, _inputValue, _auxData);
+
+        // Associate nonce to position
+        positionByNonce[_interactionNonce] = _positionId;
+
+        // Accumulate subsidy to _rollupBeneficiary
+        SUBSIDY.claimSubsidy(_criteria, _rollupBeneficiary);
+        
+        return (0, 0, true);
+    }
 
     /**
      * @notice Defines subsidies for DCA pairs
@@ -151,7 +189,51 @@ contract MeanBridge is BridgeBase, Ownable2Step {
      */
     function computeCriteriaForPosition(address _from, address _to, uint32 _amountOfSwaps, uint32 _swapInterval) public pure returns (uint256) {
         return uint256(keccak256(abi.encodePacked(_from, _to, _amountOfSwaps, _swapInterval)));
-    }    
+    }
+
+    function _wrapAndDeposit(
+        AztecTypes.AztecAsset memory _inputAssetA, 
+        AztecTypes.AztecAsset memory _outputAssetA,
+        uint256 _inputValue,
+        uint64 _auxData
+    ) internal returns(uint256 _positionId, uint256 _criteria) {
+        // Calculate input params
+        (address _from, address _to, uint32 _amountOfSwaps, uint32 _swapInterval) = _mapToPositionData(_inputAssetA, _outputAssetA, _auxData);
+
+        // Wrap input asset if needed
+        uint256 _amountToDeposit = _wrapIfNeeded(_inputAssetA, _from, _inputValue);
+
+        // Make the actual deposit
+        _positionId = DCA_HUB.deposit(
+            _from,
+            _to,
+            _amountToDeposit,
+            _amountOfSwaps,
+            _swapInterval,
+            THIS_ADDRESS,
+            new IDCAHub.PermissionSet[](0)
+        );
+
+        // Compute the criteria for this position
+        _criteria = computeCriteriaForPosition(_from, _to, _amountOfSwaps, _swapInterval);
+    }
+
+    function _wrapIfNeeded(AztecTypes.AztecAsset memory _inputAsset, address _hubToken, uint256 _amountToWrap) internal returns (uint256 _wrappedAmount) {
+        if (_inputAsset.assetType == AztecTypes.AztecAssetType.ETH) {
+            WETH.deposit{value: _amountToWrap}();            
+        } else if (_inputAsset.erc20Address != _hubToken) {
+            ITransformer.UnderlyingAmount[] memory _underlying = new ITransformer.UnderlyingAmount[](1);
+            _underlying[0] = ITransformer.UnderlyingAmount({underlying: _inputAsset.erc20Address, amount: _amountToWrap});
+            return TRANSFORMER_REGISTRY.transformToDependent(
+                _hubToken,
+                _underlying,
+                THIS_ADDRESS,
+                0, // We can't set slippage amount through Aztec, so we set the min to zero. Would be the same as calling `deposit` on a ERC4626
+                block.timestamp
+            );        
+        }
+        return _amountToWrap;
+    }
 
     function _maxApprove(IERC20 _token, address _target) internal {
         // Using safeApprove(...) instead of approve(...) and first setting the allowance to 0 because underlying

--- a/src/bridges/mean/MeanBridge.sol
+++ b/src/bridges/mean/MeanBridge.sol
@@ -58,6 +58,17 @@ contract MeanBridge is BridgeBase, Ownable2Step {
     receive() external payable {}
 
     /**
+     * @notice Defines subsidies for DCA pairs
+     * @dev Can only be called by the contract's owner
+     */
+    function setSubsidies(
+        uint256[] calldata _criteria,
+        uint32[] calldata _gasUsage,
+        uint32[] calldata _minGasPerMinute) external onlyOwner {
+        SUBSIDY.setGasUsageAndMinGasPerMinute(_criteria, _gasUsage, _minGasPerMinute);
+    }
+
+    /**
      * @notice Registers wrappers internally, so that they can be referenced by an index instead of the full address
      * @dev Anyone can call this method, it's not permissioned
      * @param _wrappers The wrappers to register

--- a/src/bridges/mean/MeanBridge.sol
+++ b/src/bridges/mean/MeanBridge.sol
@@ -129,9 +129,10 @@ contract MeanBridge is BridgeBase, Ownable2Step {
         (uint256 _unswapped, uint256 _swapped) = DCA_HUB.terminate(_positionId, THIS_ADDRESS, THIS_ADDRESS);
 
         if (_unswapped > 0) {
-            if (!DCA_HUB.paused()) {
-                // If there are still unswapped funds, then we will only allow closing the DCA position
-                // if swaps have been paused
+            // If there are still unswapped funds, then we will only allow users to close their DCA position if:
+            // - Swaps have been paused
+            // - One of the tokens is no longer allowed on the platform
+            if (!DCA_HUB.paused() && DCA_HUB.allowedTokens(_from) && DCA_HUB.allowedTokens(_to)) {                
                 revert MeanErrorLib.PositionStillOngoing();
             }
 

--- a/src/bridges/mean/MeanBridge.sol
+++ b/src/bridges/mean/MeanBridge.sol
@@ -129,7 +129,8 @@ contract MeanBridge is BridgeBase, Ownable2Step {
         (uint256 _unswapped, uint256 _swapped) = DCA_HUB.terminate(_positionId, THIS_ADDRESS, THIS_ADDRESS);
 
         if (_unswapped > 0) {
-            // If there are still unswapped funds, then we will only allow users to close their DCA position if:
+            // If there are still unswapped funds, then we will only allow users to close their DCA position 
+            // if one of the following options is met:
             // - Swaps have been paused
             // - One of the tokens is no longer allowed on the platform
             if (!DCA_HUB.paused() && DCA_HUB.allowedTokens(_from) && DCA_HUB.allowedTokens(_to)) {                

--- a/src/bridges/mean/MeanBridge.sol
+++ b/src/bridges/mean/MeanBridge.sol
@@ -98,6 +98,11 @@ contract MeanBridge is BridgeBase, Ownable2Step {
 
     /**
      * @notice A function which will allow the users to close their DCA positions on Mean Finance
+     * @dev Positions can only be finalised if one of the following is true:
+     *      - Position has been fully swapped
+     *      - Swaps are paused
+     *      - "From" token is no longer supported
+     *      - "To" token is no longer supported
      * @param _outputAssetA - ETH or ERC20 token that the position had swapped funds into
      * @param _outputAssetB - ETH or ERC20 token that had been deposited by the user
      * @param _interactionNonce - Unique identifier for this DeFi interaction

--- a/src/bridges/mean/MeanErrorLib.sol
+++ b/src/bridges/mean/MeanErrorLib.sol
@@ -9,5 +9,8 @@ library MeanErrorLib {
 
     /// @notice Thrown when trying to register a token that is already registered
     error TokenAlreadyRegistered(address token);
+
+    /// @notice Thrown when trying to close a position that is still ongoing
+    error PositionStillOngoing();
     
 }

--- a/src/bridges/mean/MeanErrorLib.sol
+++ b/src/bridges/mean/MeanErrorLib.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Aztec.
+pragma solidity >=0.8.4;
+
+library MeanErrorLib {
+
+    /// @notice Thrown when trying to registered a token that is not suported by Mean
+    error TokenNotAllowed(address token);
+
+    /// @notice Thrown when trying to register a token that is already registered
+    error TokenAlreadyRegistered(address token);
+    
+}

--- a/src/bridges/mean/MeanSwapIntervalDecodingLib.sol
+++ b/src/bridges/mean/MeanSwapIntervalDecodingLib.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Aztec.
+pragma solidity >=0.8.4;
+
+import {ErrorLib} from "../base/ErrorLib.sol";
+
+library MeanSwapIntervalDecodingLib {
+
+    function calculateSwapInterval(uint8 _swapIntervalCode) internal pure returns (uint32) {
+        if (_swapIntervalCode == 0) {
+            return 1 weeks;
+        } else if (_swapIntervalCode == 1) {
+            return 1 days;
+        } else if (_swapIntervalCode == 2) {
+            return 4 hours;
+        } else if (_swapIntervalCode == 3) {
+            return 1 hours;
+        } else if (_swapIntervalCode == 4) {
+            return 30 minutes;
+        } else if (_swapIntervalCode == 5) {
+            return 15 minutes;
+        } else if (_swapIntervalCode == 6) {
+            return 5 minutes;
+        } else if (_swapIntervalCode == 7) {
+            return 1 minutes;
+        } else {
+            revert ErrorLib.InvalidAuxData();
+        }
+    }
+}

--- a/src/interfaces/mean/IDCAHub.sol
+++ b/src/interfaces/mean/IDCAHub.sol
@@ -3,26 +3,6 @@ pragma solidity >=0.8.4;
 
 interface IDCAHub {
 
-  /// @notice The position of a certain user
-  struct UserPosition {
-    // The token that the user deposited and will be swapped in exchange for "to"
-    address from;
-    // The token that the user will get in exchange for their "from" tokens in each swap
-    address to;
-    // How frequently the position's swaps should be executed
-    uint32 swapInterval;
-    // How many swaps were executed since deposit, last modification, or last withdraw
-    uint32 swapsExecuted;
-    // How many "to" tokens can currently be withdrawn
-    uint256 swapped;
-    // How many swaps left the position has to execute
-    uint32 swapsLeft;
-    // How many "from" tokens there are left to swap
-    uint256 remaining;
-    // How many "from" tokens need to be traded in each swap
-    uint120 rate;
-  }
-
   /// @notice Set of possible permissions
   enum Permission {
     INCREASE,
@@ -39,13 +19,6 @@ interface IDCAHub {
     Permission[] permissions;
   }
   
-  /**
-   * @notice Returns a user position
-   * @param positionId The id of the position
-   * @return position The position itself
-   */
-  function userPosition(uint256 positionId) external view returns (UserPosition memory position);
-
   /**
    * @notice Returns whether swaps and deposits are currently paused
    * @return isPaused Whether swaps and deposits are currently paused

--- a/src/test/bridges/mean/MeanBridgeE2E.t.sol
+++ b/src/test/bridges/mean/MeanBridgeE2E.t.sol
@@ -1,0 +1,459 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2022 Aztec.
+pragma solidity >=0.8.4;
+
+import {BridgeTestBase} from "../../aztec/base/BridgeTestBase.sol";
+import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import {AztecTypes} from "rollup-encoder/libraries/AztecTypes.sol";
+import {MeanBridge} from "../../../bridges/mean/MeanBridge.sol";
+import {IDCAHub} from "../../../interfaces/mean/IDCAHub.sol";
+import {ITransformerRegistry} from "../../../interfaces/mean/ITransformerRegistry.sol";
+import {ITransformer} from "../../../interfaces/mean/ITransformer.sol";
+import {ErrorLib} from "../../../bridges/base/ErrorLib.sol";
+import {DCAHubSwapperMock} from './mocks/Swapper.sol';
+
+contract MeanBridgeE2eTest is BridgeTestBase {
+
+    address private constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+    address private constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address public constant YIELD_BEARING_DAI = 0xc4113b7605D691E073c162809060b6C5Ae402F1e;
+    address public constant YIELD_BEARING_WETH = 0xd4dE9D2Fc1607d1DF63E1c95ecBfa8d7946f5457;
+    address private constant BRIDGE_OWNER = 0x0000000000000000000000000000000000000001;
+    address private constant HUB_OWNER = 0xEC864BE26084ba3bbF3cAAcF8F6961A9263319C4;
+    ExtendedHub private constant HUB = ExtendedHub(0xA5AdC5484f9997fBF7D405b9AA62A7d88883C345);
+    ITransformerRegistry private constant TRANSFORMER_REGISTRY = ITransformerRegistry(0xC0136591Df365611B1452B5F8823dEF69Ff3A685);
+    MeanBridge private bridge;
+    DCAHubSwapperMock private swapper;
+    uint256 private bridgeId;
+    
+    function setUp() public {
+        bridge = new MeanBridge(IDCAHub(address(HUB)), TRANSFORMER_REGISTRY, BRIDGE_OWNER, address(ROLLUP_PROCESSOR));
+        bridge = new MeanBridge(IDCAHub(address(HUB)), TRANSFORMER_REGISTRY, BRIDGE_OWNER, address(ROLLUP_PROCESSOR));
+
+        // Approve tokens
+        IERC20[] memory _toApprove = new IERC20[](2);
+        _toApprove[0] = IERC20(DAI);
+        _toApprove[1] = IERC20(WETH);
+        bridge.maxApprove(_toApprove);
+
+        // Register yield-bearing-wrappers
+        address[] memory _yieldBearing = new address[](2);
+        _yieldBearing[0] = YIELD_BEARING_DAI;
+        _yieldBearing[1] = YIELD_BEARING_WETH;
+        vm.prank(BRIDGE_OWNER);
+        bridge.registerWrappers(_yieldBearing);
+
+        vm.prank(MULTI_SIG);
+        ROLLUP_PROCESSOR.setSupportedBridge(address(bridge), 600_000);
+        bridgeId = ROLLUP_PROCESSOR.getSupportedBridgesLength();
+        swapper = new DCAHubSwapperMock();
+
+        vm.label(address(bridge), "MeanBridge");
+        vm.label(address(HUB), "DCAHub");
+        vm.label(address(TRANSFORMER_REGISTRY), "TRANSFORMER_REGISTRY");
+        vm.label(DAI, 'DAI');
+        vm.label(WETH, 'WETH');
+        vm.label(YIELD_BEARING_DAI, 'YIELD_BEARING_DAI');
+        vm.label(YIELD_BEARING_WETH, 'YIELD_BEARING_WETH');
+    }
+
+    function testEthToERC20(uint120 _inputAmount) public {
+        vm.assume(0 < _inputAmount && _inputAmount <= uint120(type(int120).max));
+
+        AztecTypes.AztecAsset memory _inputAsset = ROLLUP_ENCODER.getRealAztecAsset(address(0));
+        AztecTypes.AztecAsset memory _outputAsset = ROLLUP_ENCODER.getRealAztecAsset(DAI);
+        address _hubFrom = WETH;
+        address _hubTo = DAI;
+
+        // Deposit to rollup processor
+        _dealToRollup(_inputAsset, _inputAmount);
+
+        // Create DCA position
+        uint256 _positionId = _convert(_inputAsset, _outputAsset, _hubFrom, _hubTo, _inputAmount);        
+
+        // Validate position
+        _validatePosition(_positionId, _hubFrom, _hubTo, _inputAmount);
+
+        // Perform swap
+        _swap(_hubFrom, _hubTo);
+        uint256 _swappedAmount = _calculateSwapped(_positionId);
+        
+        // Close position
+        uint256 _initialBalanceInput = _calculateBalance(_inputAsset);
+        uint256 _initialBalanceOutput = _calculateBalance(_outputAsset);
+        _finalise();
+
+        // Perform checks
+        _assertPositionWasTerminated(_positionId);
+        _assertBalance(_inputAsset, _initialBalanceInput, 0);
+        _assertBalance(_outputAsset, _initialBalanceOutput, _swappedAmount);
+    }  
+
+    function testYieldToETH(uint120 _inputAmount) public {
+        vm.assume(1 ether <= _inputAmount && _inputAmount <= 15 ether);
+
+        AztecTypes.AztecAsset memory _inputAsset = ROLLUP_ENCODER.getRealAztecAsset(DAI);
+        AztecTypes.AztecAsset memory _outputAsset = ROLLUP_ENCODER.getRealAztecAsset(address(0));
+        address _hubFrom = YIELD_BEARING_DAI;
+        address _hubTo = WETH;
+
+        // Deposit to rollup processor
+        _dealToRollup(_inputAsset, _inputAmount);
+
+        // Create DCA position
+        uint256 _positionId = _convert(_inputAsset, _outputAsset, _hubFrom, _hubTo, _inputAmount);        
+
+        // Validate position
+        uint256 _depositAmount = _calculateToYieldBearing(YIELD_BEARING_DAI, DAI, _inputAmount);
+        _validatePosition(_positionId, _hubFrom, _hubTo, _depositAmount);
+
+        // Perform swap
+        _swap(_hubFrom, _hubTo);
+        uint256 _swappedAmount = _calculateSwapped(_positionId);
+        
+        // Close position
+        uint256 _initialBalanceInput = _calculateBalance(_inputAsset);
+        uint256 _initialBalanceOutput = _calculateBalance(_outputAsset);
+        _finalise();
+
+        // Perform checks
+        _assertPositionWasTerminated(_positionId);
+        _assertBalance(_inputAsset, _initialBalanceInput, 0);
+        _assertBalance(_outputAsset, _initialBalanceOutput, _swappedAmount);
+    }
+
+    function testERC20ToYieldETH(uint120 _inputAmount) public {
+        vm.assume(0.5 ether <= _inputAmount && _inputAmount <= 10_000 ether);
+
+        AztecTypes.AztecAsset memory _inputAsset = ROLLUP_ENCODER.getRealAztecAsset(address(DAI));
+        AztecTypes.AztecAsset memory _outputAsset = ROLLUP_ENCODER.getRealAztecAsset(address(0));
+        address _hubFrom = DAI;
+        address _hubTo = YIELD_BEARING_WETH;
+
+        // Deposit to rollup processor
+        _dealToRollup(_inputAsset, _inputAmount);
+
+        // Create DCA position
+        uint256 _positionId = _convert(_inputAsset, _outputAsset, _hubFrom, _hubTo, _inputAmount);        
+
+        // Validate position
+        _validatePosition(_positionId, _hubFrom, _hubTo, _inputAmount);
+
+        // Perform swap
+        _swap(_hubFrom, _hubTo);
+        uint256 _swappedAmount = _calculateSwapped(_positionId);
+        uint256 _swappedUnderlying = _calculateToUnderlying(YIELD_BEARING_WETH, _swappedAmount);
+
+        
+        // Close position
+        uint256 _initialBalanceInput = _calculateBalance(_inputAsset);
+        uint256 _initialBalanceOutput = _calculateBalance(_outputAsset);
+        _finalise();
+
+        // Perform checks
+        _assertPositionWasTerminated(_positionId);
+        _assertBalance(_inputAsset, _initialBalanceInput, 0);
+        _assertBalance(_outputAsset, _initialBalanceOutput, _swappedUnderlying);
+    }
+
+    function testYieldETHToYieldERC20() public {
+        uint120 _inputAmount = 1 ether;
+
+        AztecTypes.AztecAsset memory _inputAsset = ROLLUP_ENCODER.getRealAztecAsset(address(0));
+        AztecTypes.AztecAsset memory _outputAsset = ROLLUP_ENCODER.getRealAztecAsset(address(DAI));
+        address _hubFrom = YIELD_BEARING_WETH;
+        address _hubTo = YIELD_BEARING_DAI;
+
+        // Deposit to rollup processor
+        _dealToRollup(_inputAsset, _inputAmount);
+
+        // Create DCA position
+        uint256 _positionId = _convert(_inputAsset, _outputAsset, _hubFrom, _hubTo, _inputAmount);   
+        uint256 _depositAmount = _calculateToYieldBearing(YIELD_BEARING_WETH, WETH, _inputAmount);
+
+        // Validate position
+        _validatePosition(_positionId, _hubFrom, _hubTo, _depositAmount);
+
+        // Perform swap
+        _swap(_hubFrom, _hubTo);
+        
+        // Close position
+        uint256 _initialBalanceInput = _calculateBalance(_inputAsset);
+        _finalise();
+
+        // Perform checks
+        _assertPositionWasTerminated(_positionId);
+        _assertBalance(_inputAsset, _initialBalanceInput, 0);
+        // Note: Euler returns some wei less that expected, so we don't test it here
+    }
+
+    function testFinaliseIfSwapsPaused(uint120 _inputAmount) public {
+        vm.assume(0 < _inputAmount && _inputAmount <= uint120(type(int120).max));
+
+        AztecTypes.AztecAsset memory _inputAsset = ROLLUP_ENCODER.getRealAztecAsset(address(0));
+        AztecTypes.AztecAsset memory _outputAsset = ROLLUP_ENCODER.getRealAztecAsset(DAI);
+        address _hubFrom = WETH;
+        address _hubTo = DAI;
+
+        // Deposit to rollup processor
+        _dealToRollup(_inputAsset, _inputAmount);
+
+        // Create DCA position
+        uint256 _positionId = _convert(_inputAsset, _outputAsset, _hubFrom, _hubTo, _inputAmount);        
+
+        // Pause swaps
+        vm.prank(HUB_OWNER);
+        HUB.pause();
+
+        // Close position
+        uint256 _initialBalanceInput = _calculateBalance(_inputAsset);
+        uint256 _initialBalanceOutput = _calculateBalance(_outputAsset);
+        _finalise();
+
+        // Perform checks
+        _assertPositionWasTerminated(_positionId);
+        _assertBalance(_inputAsset, _initialBalanceInput, _inputAmount);
+        _assertBalance(_outputAsset, _initialBalanceOutput, 0);
+    }
+
+    function testFinaliseIfFromIsNotAllowed(uint120 _inputAmount) public {
+        vm.assume(0 < _inputAmount && _inputAmount <= uint120(type(int120).max));
+
+        AztecTypes.AztecAsset memory _inputAsset = ROLLUP_ENCODER.getRealAztecAsset(address(0));
+        AztecTypes.AztecAsset memory _outputAsset = ROLLUP_ENCODER.getRealAztecAsset(DAI);
+        address _hubFrom = WETH;
+        address _hubTo = DAI;
+
+        // Deposit to rollup processor
+        _dealToRollup(_inputAsset, _inputAmount);
+
+        // Create DCA position
+        uint256 _positionId = _convert(_inputAsset, _outputAsset, _hubFrom, _hubTo, _inputAmount);        
+
+        // Unallow from
+        _unallow(_hubFrom);
+
+        // Close position
+        uint256 _initialBalanceInput = _calculateBalance(_inputAsset);
+        uint256 _initialBalanceOutput = _calculateBalance(_outputAsset);
+        _finalise();
+
+        // Perform checks
+        _assertPositionWasTerminated(_positionId);
+        _assertBalance(_inputAsset, _initialBalanceInput, _inputAmount);
+        _assertBalance(_outputAsset, _initialBalanceOutput, 0);
+    }   
+
+    function testFinaliseIfToIsNotAllowed(uint120 _inputAmount) public {
+        vm.assume(0 < _inputAmount && _inputAmount <= uint120(type(int120).max));
+
+        AztecTypes.AztecAsset memory _inputAsset = ROLLUP_ENCODER.getRealAztecAsset(address(0));
+        AztecTypes.AztecAsset memory _outputAsset = ROLLUP_ENCODER.getRealAztecAsset(DAI);
+        address _hubFrom = WETH;
+        address _hubTo = DAI;
+
+        // Deposit to rollup processor
+        _dealToRollup(_inputAsset, _inputAmount);
+
+        // Create DCA position
+        uint256 _positionId = _convert(_inputAsset, _outputAsset, _hubFrom, _hubTo, _inputAmount);        
+
+        // Unallow to
+        _unallow(_hubTo);
+
+        // Close position
+        uint256 _initialBalanceInput = _calculateBalance(_inputAsset);
+        uint256 _initialBalanceOutput = _calculateBalance(_outputAsset);
+        _finalise();
+
+        // Perform checks
+        _assertPositionWasTerminated(_positionId);
+        _assertBalance(_inputAsset, _initialBalanceInput, _inputAmount);
+        _assertBalance(_outputAsset, _initialBalanceOutput, 0);
+    }    
+
+    function _dealToRollup(AztecTypes.AztecAsset memory _asset, uint256 _amount) internal {
+        if (_asset.assetType == AztecTypes.AztecAssetType.ETH) {
+            deal(address(ROLLUP_PROCESSOR), _amount);
+        } else {
+            deal(_asset.erc20Address, address(ROLLUP_PROCESSOR), _amount);
+        }
+    }
+
+    function _convert(
+        AztecTypes.AztecAsset memory _input,
+        AztecTypes.AztecAsset memory _output,
+        address _from, 
+        address _to, 
+        uint256 _inputAmount        
+    ) internal returns (uint256 _positionId) {
+        uint64 _auxData =_buildAuxData(_from, _to, 1, 3);
+        ROLLUP_ENCODER.defiInteractionL2(bridgeId, _input, emptyAsset, _output, _input, _auxData, _inputAmount);
+        (uint256 _outputValueA, uint256 _outputValueB, bool _isAsync) = ROLLUP_ENCODER.processRollupAndGetBridgeResult();
+        assertEq(_outputValueA, 0);
+        assertEq(_outputValueB, 0);
+        assertTrue(_isAsync);
+        _positionId = bridge.positionByNonce(0); 
+    }
+
+    function _buildAuxData(address _from, address _to, uint24 _amountOfSwaps, uint8 _swapIntervalCode) internal view returns (uint64) {
+        uint32 _wrapperIdFrom = bridge.getWrapperId(_from);
+        uint32 _wrapperIdTo = bridge.getWrapperId(_to);
+        return _amountOfSwaps 
+            + (uint64(_swapIntervalCode) << 24)
+            + (uint64(_wrapperIdFrom) << 32) 
+            + (uint64(_wrapperIdTo) << 48);
+    }
+
+    function _validatePosition(
+        uint256 _positionId,
+        address _expectedFrom, 
+        address _expectedTo,
+        uint256 _deposited
+    ) internal {
+        ExtendedHub.UserPosition memory _position = HUB.userPosition(_positionId);
+        assertEq(_position.from, _expectedFrom, "Invalid from");
+        assertEq(_position.to, _expectedTo, "Invalid to");
+        assertEq(_position.swapInterval, 1 hours, "Invalid swap interval");
+        assertEq(_position.swapsExecuted, 0);
+        assertEq(_position.swapped, 0);
+        assertEq(_position.swapsLeft, 1);
+        assertEq(_position.remaining, _deposited, "Invalid remaining");
+        assertEq(_position.rate, _deposited, "Invalid rate");
+    }
+
+    function _swap(address _from, address _to) internal {
+        (address _tokenA, address _tokenB) = _from < _to
+            ? (_from, _to)
+            : (_to, _from);
+        address[] memory _tokens = new address[](2);
+        _tokens[0] = _tokenA;
+        _tokens[1] = _tokenB;
+        ExtendedHub.PairIndexes[] memory _pairs = new ExtendedHub.PairIndexes[](1);
+        _pairs[0] = ExtendedHub.PairIndexes(0, 1);
+        ExtendedHub.SwapInfo memory _swapInfo = HUB.getNextSwapInfo(_tokens, _pairs, true, '');
+        uint256 _toProvide = _swapInfo.tokens[0].toProvide + _swapInfo.tokens[1].toProvide;
+        deal(_to, address(swapper), _toProvide);
+        HUB.swap(
+            _tokens,
+            _pairs,
+            address(swapper),
+            address(swapper),
+            new uint256[](2),
+            '',
+            ''
+        );
+        
+    }
+    function _calculateSwapped(uint256 _positionId) internal view returns (uint256 _swapped) {
+        ExtendedHub.UserPosition memory _position = HUB.userPosition(_positionId);
+        return _position.swapped;
+    }
+
+    function _finalise() internal {
+        bool interactionCompleted = ROLLUP_PROCESSOR.processAsyncDefiInteraction(0);
+        assertEq(interactionCompleted, true);
+    }
+
+    function _assertPositionWasTerminated(uint256 _positionId) internal {
+        bool _isTerminated = HUB.userPosition(_positionId).swapInterval == 0;
+        assertTrue(_isTerminated, 'Position was not terminated');
+    }
+
+    function _assertBalance(AztecTypes.AztecAsset memory _asset, uint256 _initial, uint256 _diff) internal {
+        uint256 _current = _calculateBalance(_asset);
+        assertEq(_current - _initial, _diff, 'Balance check failed');
+    }
+
+    function _calculateBalance(AztecTypes.AztecAsset memory _asset) internal view returns(uint256) {
+        return (_asset.assetType == AztecTypes.AztecAssetType.ETH)
+            ? address(ROLLUP_PROCESSOR).balance
+            : IERC20(_asset.erc20Address).balanceOf(address(ROLLUP_PROCESSOR));
+    }
+
+    function _calculateToYieldBearing(address _yieldBearing, address _underlying, uint256 _amount) internal view returns (uint256) {
+        ITransformer.UnderlyingAmount[] memory _input = new ITransformer.UnderlyingAmount[](1);
+        _input[0] = ITransformer.UnderlyingAmount(_underlying, _amount);
+        return TRANSFORMER_REGISTRY.calculateTransformToDependent(_yieldBearing, _input);
+    }
+
+    function _calculateToUnderlying(address _yieldBearing, uint256 _amount) internal view returns (uint256) {
+        ITransformer.UnderlyingAmount[] memory _result = TRANSFORMER_REGISTRY.calculateTransformToUnderlying(_yieldBearing, _amount);
+        return _result[0].amount;
+    }
+
+    function _unallow(address _token) internal {
+        address[] memory _tokens = new address[](1);
+        _tokens[0] = _token;
+
+        bool[] memory _allowed = new bool[](1);
+        _allowed[0] = false;
+        vm.prank(HUB_OWNER);
+        HUB.setAllowedTokens(_tokens, _allowed);
+    }
+}
+
+// An extended version of the DCA Hub
+interface ExtendedHub {
+
+    struct UserPosition {
+        address from;
+        address to;
+        uint32 swapInterval;
+        uint32 swapsExecuted;
+        uint256 swapped;
+        uint32 swapsLeft;
+        uint256 remaining;
+        uint120 rate;
+    }
+
+    struct PairIndexes {
+        uint8 indexTokenA;
+        uint8 indexTokenB;
+    }
+
+    struct SwapInfo {
+        TokenInSwap[] tokens;
+        PairInSwap[] pairs;
+    }
+
+    struct TokenInSwap {
+        address token;
+        uint256 reward;
+        uint256 toProvide;
+        uint256 platformFee;
+    }
+
+    struct PairInSwap {
+        address tokenA;
+        address tokenB;
+        uint256 totalAmountToSwapTokenA;
+        uint256 totalAmountToSwapTokenB;
+        uint256 ratioAToB;
+        uint256 ratioBToA;
+        bytes1 intervalsInSwap;
+    }
+
+    function userPosition(uint256 positionId) external view returns (UserPosition memory position);
+
+    function getNextSwapInfo(
+        address[] calldata tokens,
+        PairIndexes[] calldata pairs,
+        bool calculatePrivilegedAvailability,
+        bytes calldata oracleData
+    ) external view returns (SwapInfo memory swapInformation);
+
+    function swap(
+        address[] calldata tokens,
+        PairIndexes[] calldata pairsToSwap,
+        address rewardRecipient,
+        address callbackHandler,
+        uint256[] calldata borrow,
+        bytes calldata callbackData,
+        bytes calldata oracleData
+    ) external returns (SwapInfo memory);
+
+    function pause() external; 
+
+    function setAllowedTokens(address[] calldata _tokens, bool[] calldata _allowed) external;
+}

--- a/src/test/bridges/mean/MeanBridgeUnit.t.sol
+++ b/src/test/bridges/mean/MeanBridgeUnit.t.sol
@@ -45,7 +45,7 @@ contract MeanBridgeUnitTest is Test {
         assertEq(address(bridge.DCA_HUB()), address(DCA_HUB));
         assertEq(address(bridge.TRANSFORMER_REGISTRY()), address(TRANSFORMER_REGISTRY));
         assertEq(bridge.owner(), OWNER);
-        assertFalse(bridge.isWrapperSupported(address(DAI)));
+        assertEq(bridge.getWrapperId(address(DAI)), 0);
     }
 
     function testMaxApprove() public {
@@ -57,7 +57,7 @@ contract MeanBridgeUnitTest is Test {
         assertEq(DAI.allowance(address(bridge), rollupProcessor), type(uint256).max);
     }
 
-    function testRevetsWhenRegisteringWrapperThatIsNotAllowed() public {
+    function testRevertsWhenRegisteringWrapperThatIsNotAllowed() public {
         vm.expectRevert(
             abi.encodeWithSelector(
                 MeanErrorLib.TokenNotAllowed.selector, 
@@ -97,7 +97,7 @@ contract MeanBridgeUnitTest is Test {
         
         assertEq(DAI.allowance(address(bridge), address(DCA_HUB)), type(uint256).max);
         assertEq(DAI.allowance(address(bridge), address(TRANSFORMER_REGISTRY)), type(uint256).max);
-        assertTrue(bridge.isWrapperSupported(address(DAI)));
+        assertEq(bridge.getWrapperId(address(DAI)), 1);
     }
 
     function _mockIsTokenAllowed(IERC20 _token, bool _isAllowed) internal {

--- a/src/test/bridges/mean/MeanBridgeUnit.t.sol
+++ b/src/test/bridges/mean/MeanBridgeUnit.t.sol
@@ -8,12 +8,14 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {MeanBridge} from "../../../bridges/mean/MeanBridge.sol";
 import {ErrorLib} from "../../../bridges/base/ErrorLib.sol";
 import {MeanErrorLib} from "../../../bridges/mean/MeanErrorLib.sol";
+import {MeanSwapIntervalDecodingLib} from "../../../bridges/mean/MeanSwapIntervalDecodingLib.sol";
 import {IDCAHub} from "../../../interfaces/mean/IDCAHub.sol";
 import {ITransformerRegistry} from "../../../interfaces/mean/ITransformerRegistry.sol";
 
 contract MeanBridgeUnitTest is Test {
     IERC20 public constant WETH = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
     IERC20 public constant DAI = IERC20(0x6B175474E89094C44Da98b954EedeAC495271d0F);
+    IERC20 public constant DAI_WRAPPER = IERC20(0x4169Df1B7820702f566cc10938DA51F6F597d264);
     address public constant OWNER = 0x0000000000000000000000000000000000000001;
     IDCAHub public constant DCA_HUB = IDCAHub(0x0000000000000000000000000000000000000002);
     ITransformerRegistry public constant TRANSFORMER_REGISTRY = ITransformerRegistry(0x0000000000000000000000000000000000000003);
@@ -45,7 +47,7 @@ contract MeanBridgeUnitTest is Test {
         assertEq(address(bridge.DCA_HUB()), address(DCA_HUB));
         assertEq(address(bridge.TRANSFORMER_REGISTRY()), address(TRANSFORMER_REGISTRY));
         assertEq(bridge.owner(), OWNER);
-        assertEq(bridge.getWrapperId(address(DAI)), 0);
+        assertEq(bridge.getWrapperId(address(DAI_WRAPPER)), 0);
     }
 
     function testMaxApprove() public {
@@ -61,25 +63,25 @@ contract MeanBridgeUnitTest is Test {
         vm.expectRevert(
             abi.encodeWithSelector(
                 MeanErrorLib.TokenNotAllowed.selector, 
-                address(DAI)
+                DAI_WRAPPER
             )
         );
         
         address[] memory _tokens = new address[](1);
-        _tokens[0] = address(DAI);
-        _mockIsTokenAllowed(DAI, false);
+        _tokens[0] = address(DAI_WRAPPER);
+        _mockIsTokenAllowed(DAI_WRAPPER, false);
         bridge.registerWrappers(_tokens);
     }
 
     function testRevertsWhenRegisteringWrapperThatWasAlreadyRegistered() public {        
         address[] memory _tokens = new address[](1);
-        _tokens[0] = address(DAI);
-        _mockIsTokenAllowed(DAI, true);
+        _tokens[0] = address(DAI_WRAPPER);
+        _mockIsTokenAllowed(DAI_WRAPPER, true);
         bridge.registerWrappers(_tokens);
         vm.expectRevert(
             abi.encodeWithSelector(
                 MeanErrorLib.TokenAlreadyRegistered.selector, 
-                address(DAI)
+                DAI_WRAPPER
             )
         );
         bridge.registerWrappers(_tokens);
@@ -87,17 +89,70 @@ contract MeanBridgeUnitTest is Test {
 
     function testRegisterWrappers() public {
         address[] memory _tokens = new address[](1);
-        _tokens[0] = address(DAI);
+        _tokens[0] = address(DAI_WRAPPER);
         
         vm.expectEmit(true, false, false, false, address(bridge));
         emit NewWrappersSupported(_tokens);
         
-        _mockIsTokenAllowed(DAI, true);
+        _mockIsTokenAllowed(DAI_WRAPPER, true);
         bridge.registerWrappers(_tokens);
         
-        assertEq(DAI.allowance(address(bridge), address(DCA_HUB)), type(uint256).max);
-        assertEq(DAI.allowance(address(bridge), address(TRANSFORMER_REGISTRY)), type(uint256).max);
-        assertEq(bridge.getWrapperId(address(DAI)), 1);
+        assertEq(DAI_WRAPPER.allowance(address(bridge), address(DCA_HUB)), type(uint256).max);
+        assertEq(DAI_WRAPPER.allowance(address(bridge), address(TRANSFORMER_REGISTRY)), type(uint256).max);
+        assertEq(bridge.getWrapperId(address(DAI_WRAPPER)), 1);
+    }
+
+    function testComputeCriteriaWithERC20s(address _from, address _to, uint24 _amountOfSwaps, uint8 _swapIntervalCode) public {
+        vm.assume(_swapIntervalCode < 8);
+        uint64 _auxData = _buildAuxData(_amountOfSwaps, _swapIntervalCode);
+
+        uint256 _actual = bridge.computeCriteria(
+            _erc20Asset(_from),
+            emptyAsset, 
+            _erc20Asset(_to),
+            emptyAsset, 
+            _auxData
+        );
+        uint256 _expected = _criteriaFor(_from, _to, _amountOfSwaps, _swapIntervalCode);
+        assertEq(_actual, _expected);
+    }        
+
+    function testComputeCriteriaWithEthAsFromAndWrapperAsTo(uint24 _amountOfSwaps, uint8 _swapIntervalCode) public {
+        vm.assume(_swapIntervalCode < 8);
+        _registerDAIWrapper();
+
+        uint64 _auxData = _buildAuxData(_amountOfSwaps, _swapIntervalCode, 0, 1);
+        uint256 _actual = bridge.computeCriteria(
+            _ethAsset(),
+            emptyAsset, 
+            _erc20Asset(address(DAI)),
+            emptyAsset, 
+            _auxData
+        );
+        uint256 _expected = _criteriaFor(address(WETH), address(DAI_WRAPPER), _amountOfSwaps, _swapIntervalCode);
+        assertEq(_actual, _expected);
+    }
+
+    function testComputeCriteriaWithWrapperAsFromAndEthAsTo(uint24 _amountOfSwaps, uint8 _swapIntervalCode) public {
+        vm.assume(_swapIntervalCode < 8);
+        _registerDAIWrapper();
+
+        uint64 _auxData = _buildAuxData(_amountOfSwaps, _swapIntervalCode, 1, 0);
+        uint256 _actual = bridge.computeCriteria(
+            _erc20Asset(address(DAI)),
+            emptyAsset, 
+            _ethAsset(),
+            emptyAsset, 
+            _auxData
+        );
+        uint256 _expected = _criteriaFor(address(DAI_WRAPPER), address(WETH), _amountOfSwaps, _swapIntervalCode);
+        assertEq(_actual, _expected);
+    }
+
+    function testComputeCriteriaForPosition(address _from, address _to, uint32 _amountOfSwaps, uint32 _swapInterval) public {
+        uint256 _expected = uint256(keccak256(abi.encodePacked(_from, _to, _amountOfSwaps, _swapInterval)));
+        uint256 _actual = bridge.computeCriteriaForPosition(_from, _to, _amountOfSwaps, _swapInterval);
+        assertEq(_actual, _expected);
     }
 
     function _mockIsTokenAllowed(IERC20 _token, bool _isAllowed) internal {
@@ -109,6 +164,37 @@ contract MeanBridgeUnitTest is Test {
             ),
             abi.encode(_isAllowed)
         );
+    }
+
+    function _registerDAIWrapper() internal {
+        address[] memory _tokens = new address[](1);
+        _tokens[0] = address(DAI_WRAPPER);
+        _mockIsTokenAllowed(DAI_WRAPPER, true);
+        bridge.registerWrappers(_tokens);
+    }
+
+    function _criteriaFor(address _from, address _to, uint32 _amountOfSwaps, uint8 _swapIntervalCode) internal view returns (uint256) {
+        return bridge.computeCriteriaForPosition(_from, _to, _amountOfSwaps, MeanSwapIntervalDecodingLib.calculateSwapInterval(_swapIntervalCode));
+    }
+
+    function _erc20Asset(address _token) internal pure returns(AztecTypes.AztecAsset memory _asset) {
+        _asset.assetType = AztecTypes.AztecAssetType.ERC20;
+        _asset.erc20Address = _token;
+    }
+
+    function _ethAsset()internal pure returns(AztecTypes.AztecAsset memory _asset) {
+        _asset.assetType = AztecTypes.AztecAssetType.ETH;
+    }
+
+    function _buildAuxData(uint24 _amountOfSwaps, uint8 _swapIntervalCode) internal pure returns (uint64) {
+        return _buildAuxData(_amountOfSwaps, _swapIntervalCode, 0, 0);
+    }
+
+    function _buildAuxData(uint24 _amountOfSwaps, uint8 _swapIntervalCode, uint16 _wrapperIdFrom, uint16 _wrapperIdTo) internal pure returns (uint64) {
+        return _amountOfSwaps 
+            + (uint64(_swapIntervalCode) << 24) 
+            + (uint64(_wrapperIdFrom) << 32) 
+            + (uint64(_wrapperIdTo) << 48);
     }
 
 }

--- a/src/test/bridges/mean/MeanBridgeUnit.t.sol
+++ b/src/test/bridges/mean/MeanBridgeUnit.t.sol
@@ -88,6 +88,7 @@ contract MeanBridgeUnitTest is Test {
         
         _returnOnTerminate(100, 0);
         _setDCAPaused(false);
+        _mockIsTokenAllowed(true);
 
         vm.prank(rollupProcessor);
         bridge.finalise(emptyAsset, emptyAsset, emptyAsset, emptyAsset, 0, 0);
@@ -100,6 +101,7 @@ contract MeanBridgeUnitTest is Test {
         _registerDAIWrapper();
         _returnUnderlying(WETH);
         _returnOnTerminate(0, 100);
+        _mockIsTokenAllowed(true);
 
         vm.expectRevert(ErrorLib.InvalidOutputA.selector);
         vm.prank(rollupProcessor);
@@ -113,6 +115,7 @@ contract MeanBridgeUnitTest is Test {
         _returnUnderlying(WETH);
         _returnOnTerminate(100, 0);
         _setDCAPaused(true);
+        _mockIsTokenAllowed(true);
         
         AztecTypes.AztecAsset memory _inputAssetA = _erc20Asset(address(DAI));
 
@@ -167,14 +170,14 @@ contract MeanBridgeUnitTest is Test {
         
         address[] memory _tokens = new address[](1);
         _tokens[0] = address(DAI_WRAPPER);
-        _mockIsTokenAllowed(DAI_WRAPPER, false);
+        _mockIsTokenAllowed(false);
         bridge.registerWrappers(_tokens);
     }
 
     function testRevertsWhenRegisteringWrapperThatWasAlreadyRegistered() public {        
         address[] memory _tokens = new address[](1);
         _tokens[0] = address(DAI_WRAPPER);
-        _mockIsTokenAllowed(DAI_WRAPPER, true);
+        _mockIsTokenAllowed(true);
         bridge.registerWrappers(_tokens);
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -192,7 +195,7 @@ contract MeanBridgeUnitTest is Test {
         vm.expectEmit(true, false, false, false, address(bridge));
         emit NewWrappersSupported(_tokens);
         
-        _mockIsTokenAllowed(DAI_WRAPPER, true);
+        _mockIsTokenAllowed(true);
         bridge.registerWrappers(_tokens);
         
         assertEq(DAI_WRAPPER.allowance(address(bridge), address(DCA_HUB)), type(uint256).max);
@@ -253,13 +256,10 @@ contract MeanBridgeUnitTest is Test {
         assertEq(_actual, _expected);
     }
 
-    function _mockIsTokenAllowed(IERC20 _token, bool _isAllowed) internal {
+    function _mockIsTokenAllowed(bool _isAllowed) internal {
         vm.mockCall(
             address(DCA_HUB),
-            abi.encodeWithSelector(
-                DCA_HUB.allowedTokens.selector,
-                address(_token)
-            ),
+            abi.encodeWithSelector(DCA_HUB.allowedTokens.selector),
             abi.encode(_isAllowed)
         );
     }
@@ -293,7 +293,7 @@ contract MeanBridgeUnitTest is Test {
     function _registerDAIWrapper() internal {
         address[] memory _tokens = new address[](1);
         _tokens[0] = address(DAI_WRAPPER);
-        _mockIsTokenAllowed(DAI_WRAPPER, true);
+        _mockIsTokenAllowed(true);
         bridge.registerWrappers(_tokens);
     }
 

--- a/src/test/bridges/mean/mocks/Swapper.sol
+++ b/src/test/bridges/mean/mocks/Swapper.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.7;
+
+import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+
+
+contract DCAHubSwapperMock {
+
+  struct TokenInSwap {
+    address token;
+    uint256 reward;
+    uint256 toProvide;
+    uint256 platformFee;
+  }
+
+  function DCAHubSwapCall(
+    address,
+    TokenInSwap[] calldata _tokens,
+    uint256[] calldata,
+    bytes calldata
+  ) external {
+
+    for (uint256 i; i < _tokens.length; i++) {
+      uint256 _amountToProvide = _tokens[i].toProvide;
+      if (_amountToProvide > 0) {
+        IERC20(_tokens[i].token).transfer(msg.sender, _amountToProvide);
+      }
+    }
+  }
+}


### PR DESCRIPTION
We are now introducing the Wrappers Registry. We want to support yield, but we can't pass the 4626 wrapper's address as part of the convert function. So the idea is to have a registry that would allow us to map `id => address`. Since the id is smaller (`uint16`), we can pass it as part of the `auxData`

Anyone will be able to register tokens to the registry, since we can easily make sure that there is no wrong-doing